### PR TITLE
Add status labels to blogs

### DIFF
--- a/inc/autoload/class-add-blog-status-labels.php
+++ b/inc/autoload/class-add-blog-status-labels.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Add status labels to blogs
+ *
+ * @since    14/07/2015
+ * @version  dev
+ */
+
+add_action( 'init', array( 'Multisite_Add_Blog_Status_labels', 'init' ) );
+
+class Multisite_Add_Blog_Status_labels {
+	
+	private $admin_color_scheme = false;
+	
+	public static function init() {
+
+		$class = __CLASS__;
+		if ( empty( $GLOBALS[ $class ] ) ) {
+			$GLOBALS[ $class ] = new $class;
+		}
+	}
+
+	/**
+	 * Init function to register all used hooks
+	 *
+	 * @since   dev
+	 * @return \Multisite_Add_Blog_Status_labels
+	 */
+	public function __construct() {
+		add_action( 'admin_bar_menu', array( $this, 'print_admin_bar_blog_status_labels' ) );
+	}
+	
+	
+	/**
+	 * Add status label from each blog to Multisite Menu of "My Sites"
+	 *
+	 * Use the filter hook to change style
+	 *     Hook: multisite_enhancements_add_admin_bar_favicon
+	 *
+	 * @since   dev
+	 * @return  none
+	 */
+	public function print_admin_bar_blog_status_labels( $admin_bar ) {
+
+		if (current_user_can('manage_network')) {
+				
+			global $_wp_admin_css_colors;
+			$admin_color_schemes = $_wp_admin_css_colors;
+			$this->admin_color_scheme = $admin_color_schemes[get_user_option('admin_color')];
+			
+			foreach ($admin_bar->user->blogs as $key => $blog) {
+				
+				$prefix = '';
+				
+					$label = 'ext-domain';
+					$color = 'inherit';
+					if ($this->admin_color_scheme->colors[3]) {
+						$color = $this->admin_color_scheme->colors[3];
+					}
+					if (strpos($blog->siteurl, str_replace(array('http://', 'https://', '//'), '', $admin_bar->user->domain)) === false) {
+						$prefix .= '<span style="font-style: italic; font-weight: bold; line-height: 1; color: '.$color.';">['.$label.']</span> ';
+					}
+				
+					$label = 'noindex';
+					$color = 'inherit';
+					if ($this->admin_color_scheme->colors[2]) {
+						$color = $this->admin_color_scheme->colors[2];
+					}
+					$is_live = get_blog_option($blog->userblog_id, 'blog_public', '0'); // $blog->site_id (is altijd 1)
+					if ($is_live == '0') {
+						$prefix .= '<span style="font-style: italic; font-weight: bold; line-height: 1; color: '.$color.';">['.$label.']</span> ';
+					}
+				
+				$blog->blogname = $prefix.$blog->blogname;
+				$admin_bar->user->blogs[$key]->blogname = $blog->blogname;
+			}
+					
+		}
+
+	}
+	
+} // end class


### PR DESCRIPTION
The goal of the plugin is to give network managers more on-the-spot insight in the status of their blogs. For me this was really helpfull since some of my sites were in development and some were not. It's just a quick overview (and a extra reminder so you don't forget to disable noindex for live sites).

Current labels:
- ext-domain = Shown if the blog/site has an different domain than the main site
- noindex = Shown if the blog/site is set on noindex (Settings->Reading)

TODO: Label colors are based on the admin color schemes. Though this doesn't work well with all color schemes. Need to figure out how to add a class that will allways have a contrast color on the background.