### PR TITLE
manage_users_custom_column is a filter and not an action

### DIFF
--- a/inc/autoload/class-add-blog-id.php
+++ b/inc/autoload/class-add-blog-id.php
@@ -78,8 +78,10 @@ class Multisite_Add_Blog_Id {
 	public function get_user_id( $value, $column_name, $user_id ) {
 
 		if ( 'object_id' === $column_name ) {
-			echo (int) $user_id;
+			return (int) $user_id;
 		}
+		
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
`manage_users_custom_column` is a filter. Therefore it should return the value instead of echoeing it. (For some weird reason, this is inconsistent with `manage_sites_custom_column`, which is an action.)

If `manage_users_custom_column` does not return `$value`, it may break other plugins which use the `manage_users_custom_column` filter to add another custom column. In fact, it breaks the [WP Last Login](https://wordpress.org/plugins/wp-last-login/) plugin.