### PR TITLE
Show sites with blank titles and add hints for deleted sites on the themes and plugins pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased, only in master branch
-* 
+* Show site path for sites with blank titles in the themes and plugins lists.
+* Show status of deleted sites.
+* Apply styles for archived and deleted sites in the lists.
+* Replace obsolete HTML 'nobr' element.
+
 ## [1.5.2](https://github.com/bueltge/wordpress-multisite-enhancements/compare/1.5.1...1.5.2) - 2019-11-14
 * Fix style problem on list of all sites for admin bar.
 * Change enqueue of styles and script to default variants.

--- a/inc/assets/css/wordpress-multisite-enhancements.css
+++ b/inc/assets/css/wordpress-multisite-enhancements.css
@@ -9,3 +9,7 @@ td.column-active_blogs a {
 .siteslist {
 	display: none;
 }
+
+.non-breaking {
+	white-space: nowrap;
+}

--- a/inc/assets/css/wordpress-multisite-enhancements.min.css
+++ b/inc/assets/css/wordpress-multisite-enhancements.min.css
@@ -1,1 +1,1 @@
-td.column-active_blogs{width:200px}td.column-active_blogs a{cursor:pointer;}.siteslist{display:none}
+td.column-active_blogs{width:200px}td.column-active_blogs a{cursor:pointer;}.siteslist{display:none}.non-breaking{white-space:nowrap;}

--- a/inc/autoload/class-add-plugin-list.php
+++ b/inc/autoload/class-add-plugin-list.php
@@ -35,9 +35,6 @@ class Multisite_Add_Plugin_List {
 	 */
 	static protected $wp_kses_allowed_html = array(
 		'br'   => array(),
-		'nobr' => array(
-			'class' => array(),
-		),
 		'span' => array(
 			'class' => array(),
 		),
@@ -215,8 +212,8 @@ class Multisite_Add_Plugin_List {
 						$hint  = esc_attr__( ', Deleted site', 'multisite-enhancements' );
 					}
 					$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
-					$output .= '<nobr><a href="' . get_admin_url( $key ) . 'plugins.php">'
-					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</nobr></li>';
+					$output .= '<span class="non-breaking"><a href="' . get_admin_url( $key ) . 'plugins.php">'
+					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</span></li>';
 				}
 				$output .= '</ul>';
 			}

--- a/inc/autoload/class-add-plugin-list.php
+++ b/inc/autoload/class-add-plugin-list.php
@@ -47,6 +47,7 @@ class Multisite_Add_Plugin_List {
 		),
 		'li'   => array(
 			'title' => array(),
+			'class' => array(),
 		),
 		'a'    => array(
 			'href'    => array(),
@@ -209,6 +210,10 @@ class Multisite_Add_Plugin_List {
 						$class = ' class="site-archived"';
 						$hint  = esc_attr__( ', Archived site', 'multisite-enhancements' );
 					}
+					elseif ( $this->is_deleted( $key ) ) {
+						$class = ' class="site-deleted"';
+						$hint  = esc_attr__( ', Deleted site', 'multisite-enhancements' );
+					}
 					$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
 					$output .= '<nobr><a href="' . get_admin_url( $key ) . 'plugins.php">'
 					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</nobr></li>';
@@ -352,6 +357,19 @@ class Multisite_Add_Plugin_List {
 		$site_id = (int) $site_id;
 
 		return (bool) get_blog_details( $site_id )->archived;
+	}
+
+	/**
+	 * Check, if the status of the site deleted.
+	 *
+	 * @param integer $site_id ID of the site.
+	 *
+	 * @return bool
+	 */
+	public function is_deleted( $site_id ) {
+		$site_id = (int) $site_id;
+
+		return (bool) get_blog_details( $site_id )->deleted;
 	}
 
 } // end class

--- a/inc/autoload/class-add-plugin-list.php
+++ b/inc/autoload/class-add-plugin-list.php
@@ -201,15 +201,15 @@ class Multisite_Add_Plugin_List {
 				$output .= '<ul id="siteslist_' . $plugin_file;
 				$output .= ( $is_list_hidden ) ? '">' : '" class="siteslist">';
 				foreach ( $active_on_blogs as $key => $value ) {
-					// Check the site for archived.
+					// Check the site for archived and deleted.
 					$class = $hint = '';
 					if ( $this->is_archived( $key ) ) {
 						$class = ' class="site-archived"';
-						$hint  = esc_attr__( ', Archived site', 'multisite-enhancements' );
+						$hint  = ', ' . esc_attr__( 'Archived' );
 					}
-					elseif ( $this->is_deleted( $key ) ) {
+					if ( $this->is_deleted( $key ) ) {
 						$class = ' class="site-deleted"';
-						$hint  = esc_attr__( ', Deleted site', 'multisite-enhancements' );
+						$hint  .= ', ' . esc_attr__( 'Deleted' );
 					}
 					$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
 					$output .= '<span class="non-breaking"><a href="' . get_admin_url( $key ) . 'plugins.php">'

--- a/inc/autoload/class-add-plugin-list.php
+++ b/inc/autoload/class-add-plugin-list.php
@@ -211,7 +211,7 @@ class Multisite_Add_Plugin_List {
 					}
 					$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
 					$output .= '<nobr><a href="' . get_admin_url( $key ) . 'plugins.php">'
-					. $value['name'] . '</a>' . $hint . '</nobr></li>';
+					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</nobr></li>';
 				}
 				$output .= '</ul>';
 			}

--- a/inc/autoload/class-add-theme-list.php
+++ b/inc/autoload/class-add-theme-list.php
@@ -42,6 +42,7 @@ class Multisite_Add_Theme_List {
 		),
 		'li'   => array(
 			'title' => array(),
+			'class' => array(),
 		),
 		'a'    => array(
 			'href'    => array(),
@@ -221,6 +222,10 @@ class Multisite_Add_Theme_List {
 				if ( $this->is_archived( $key ) ) {
 					$class = ' class="site-archived"';
 					$hint  = esc_attr__( ', Archived site', 'multisite-enhancements' );
+				}
+				elseif ( $this->is_deleted( $key ) ) {
+					$class = ' class="site-deleted"';
+					$hint  = esc_attr__( ', Deleted site', 'multisite-enhancements' );
 				}
 
 				$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
@@ -402,6 +407,19 @@ class Multisite_Add_Theme_List {
 		$site_id = (int) $site_id;
 
 		return (bool) get_blog_details( $site_id )->archived;
+	}
+
+	/**
+	 * Check, if the status of the site deleted.
+	 *
+	 * @param integer $site_id ID of the site.
+	 *
+	 * @return bool
+	 */
+	public function is_deleted( $site_id ) {
+		$site_id = (int) $site_id;
+
+		return (bool) get_blog_details( $site_id )->deleted;
 	}
 
 } // end class

--- a/inc/autoload/class-add-theme-list.php
+++ b/inc/autoload/class-add-theme-list.php
@@ -30,9 +30,6 @@ class Multisite_Add_Theme_List {
 	 */
 	static protected $wp_kses_allowed_html = array(
 		'br'   => array(),
-		'nobr' => array(
-			'class' => array(),
-		),
 		'span' => array(
 			'class' => array(),
 		),
@@ -132,7 +129,7 @@ class Multisite_Add_Theme_List {
 	 */
 	public function add_themes_column( $columns ) {
 
-		$columns['active_blogs'] = '<nobr>' . _x( 'Usage', 'column name', 'multisite-enhancements' ) . '</nobr>';
+		$columns['active_blogs'] = '<span class="non-breaking">' . _x( 'Usage', 'column name', 'multisite-enhancements' ) . '</span>';
 
 		return $columns;
 	}
@@ -182,7 +179,7 @@ class Multisite_Add_Theme_List {
 
 		if ( ! $active_on_blogs ) {
 			// Translators: The theme is not activated, the string is for each plugin possible.
-			$output .= __( '<nobr>Not Activated</nobr>', 'multisite-enhancements' );
+			$output .= __( '<span class="non-breaking">Not Activated</span>', 'multisite-enhancements' );
 			$output .= $child_context;
 			$output .= $parent_context;
 		} else {
@@ -229,8 +226,8 @@ class Multisite_Add_Theme_List {
 				}
 
 				$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
-				$output .= '<nobr><a href="' . get_admin_url( $key ) . 'themes.php">'
-					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</nobr>';
+				$output .= '<span class="non-breaking"><a href="' . get_admin_url( $key ) . 'themes.php">'
+					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</span>';
 				$output .= '</li>';
 			}
 

--- a/inc/autoload/class-add-theme-list.php
+++ b/inc/autoload/class-add-theme-list.php
@@ -214,15 +214,15 @@ class Multisite_Add_Theme_List {
 
 			foreach ( $active_on_blogs as $key => $value ) {
 
-				// Check the site for archived.
+				// Check the site for archived and deleted.
 				$class = $hint = '';
 				if ( $this->is_archived( $key ) ) {
 					$class = ' class="site-archived"';
-					$hint  = esc_attr__( ', Archived site', 'multisite-enhancements' );
+					$hint  = ', ' . esc_attr__( 'Archived' );
 				}
-				elseif ( $this->is_deleted( $key ) ) {
+				if ( $this->is_deleted( $key ) ) {
 					$class = ' class="site-deleted"';
-					$hint  = esc_attr__( ', Deleted site', 'multisite-enhancements' );
+					$hint  .= ', ' . esc_attr__( 'Deleted' );
 				}
 
 				$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';

--- a/inc/autoload/class-add-theme-list.php
+++ b/inc/autoload/class-add-theme-list.php
@@ -225,7 +225,7 @@ class Multisite_Add_Theme_List {
 
 				$output .= '<li' . $class . ' title="Blog ID: ' . $key . $hint . '">';
 				$output .= '<nobr><a href="' . get_admin_url( $key ) . 'themes.php">'
-					. $value['name'] . '</a>' . $hint . '</nobr>';
+					. ( trim( $value['name'] ) ?: $value['path'] ) . '</a>' . $hint . '</nobr>';
 				$output .= '</li>';
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,12 @@ I'm German and my English might be gruesome here and there.
 So please be patient with me and let me know of typos or grammatical parts. Thanks
 
 == Changelog ==
+= UNRELEASED =
+* Show site path for sites with blank titles in the themes and plugins lists.
+* Show status of deleted sites.
+* Apply styles for archived and deleted sites in the lists.
+* Replace obsolete HTML 'nobr' element.
+
 = 1.5.2 (2019-11-14) =
 * Fix style problem on list of all sites for admin bar.
 * Change enqueue of styles and script to default variants.


### PR DESCRIPTION
Hello,

I've made a small modification to display the site path for sites with blank titles, so they show properly on the network themes and plugins pages. 

Thanks for the great plugin!