### PR TITLE
Improve site label/icon positioning

### DIFF
--- a/inc/autoload/class-add-admin-favicon.php
+++ b/inc/autoload/class-add-admin-favicon.php
@@ -227,7 +227,7 @@ class Multisite_Add_Admin_Favicon {
 				. ' .blavatar { font-size: 0 !important; }';
 				$output .= '#wp-admin-bar-blog-' . $blog_id
 				. ' div.blavatar { background: url( "' . $custom_icon
-				. '" ) left bottom/16px no-repeat !important; background-size: 16px !important; margin: 0 2px 0 -2px; }' . "\n";
+				. '" ) left top no-repeat !important; background-size: 16px !important; margin: 0 2px 0 -2px; }' . "\n";
 			}
 		}
 

--- a/inc/autoload/class-add-admin-favicon.php
+++ b/inc/autoload/class-add-admin-favicon.php
@@ -231,9 +231,17 @@ class Multisite_Add_Admin_Favicon {
 			}
 		}
 
-		if ( '' !== $output ) {
+		/**
+		 * Use the filter hook to change style.
+		 *
+		 * @type string
+		 */
+		$output = apply_filters( 'multisite_enhancements_add_admin_bar_favicon_css', $output );
+
+		if ( $output ) {
+
 			/**
-			 * Use the filter hook to change style.
+			 * Use the filter hook to change style element.
 			 *
 			 * @type string
 			 */

--- a/inc/autoload/class-add-site-status-labels.php
+++ b/inc/autoload/class-add-site-status-labels.php
@@ -35,6 +35,13 @@ class Multisite_Add_Site_Status_labels {
 		if ( ! current_user_can( 'manage_network' ) ) {
 			return;
 		}
+		$this->add_hooks();
+	}
+
+	/**
+	 * Installs required hooks.
+	 */
+	public function add_hooks() {
 
 		add_filter( 'multisite_enhancements_add_admin_bar_favicon_css', array( $this, 'status_label_css' ) );
 

--- a/inc/autoload/class-add-site-status-labels.php
+++ b/inc/autoload/class-add-site-status-labels.php
@@ -36,6 +36,8 @@ class Multisite_Add_Site_Status_labels {
 			return;
 		}
 
+		add_filter( 'multisite_enhancements_add_admin_bar_favicon_css', array( $this, 'status_label_css' ) );
+
 		add_action( 'admin_bar_menu', array( $this, 'add_status_label' ) );
 	}
 
@@ -86,14 +88,14 @@ class Multisite_Add_Site_Status_labels {
 
 			if ( $this->check_external_url( $blog->siteurl, $admin_bar->user->domain ) ) {
 				$title    = esc_attr__( 'external domain', 'multisite-enhancements' );
-				$class    = 'ab-icon dashicons-before dashicons-external';
-				$url_hint = '<span style="padding:4px 0 0 0; margin: 0 4px 0 -4px" title="' . $title . '" class="' . $class . '"></span>';
+				$class    = 'site-status-icon ab-icon dashicons-before dashicons-external';
+				$url_hint = '<span title="' . $title . '" class="' . $class . '"></span>';
 			}
 
 			if ( ! $this->is_site_live( $blog->userblog_id ) ) {
 				$title     = esc_attr__( 'noindex', 'multisite-enhancements' );
-				$class     = 'ab-icon dashicons-before dashicons-dismiss';
-				$live_hint = '<span style="padding:4px 0 0 0; margin: 0 4px 0 -4px" title="' . $title . '" class="' . $class . '"></span>';
+				$class     = 'site-status-icon ab-icon dashicons-before dashicons-dismiss';
+				$live_hint = '<span title="' . $title . '" class="' . $class . '"></span>';
 			}
 
 			// Add span markup.
@@ -106,5 +108,17 @@ class Multisite_Add_Site_Status_labels {
 		}
 
 		return $admin_bar;
+	}
+
+	/**
+	 * Add required CSS for site status labels.
+	 *
+	 * @param string $css
+	 *
+	 * @return string
+	 */
+	public function status_label_css( $css = '' ) {
+		$css .= '#wp-admin-bar-my-sites-list .site-status-icon { padding: 4px 0 0 0 !important; margin: 0 4px 0 -4px !important; }';
+		return $css;
 	}
 } // end class


### PR DESCRIPTION
For site labels I've converted the inline CSS to a selector.
Much easier for other plugins to use the hook and simply apply the same styles through the selector.

Also tweaked the favicon position based on the default WP icon.