### PR TITLE
Fixing fatal error triggered by missing slash

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -6,5 +6,5 @@
 
 ! defined( 'WP_UNINSTALL_PLUGIN' ) && exit;
 
-require_once __DIR__ . 'src/settings.php';
+require_once __DIR__ . '/src/settings.php';
 delete_site_option( Multisite_Enhancements_Settings::OPTION_NAME );


### PR DESCRIPTION
Hi there, Mister Frank! 
Really cool plugin you put out there, thanks for that :)

I installed it by mistake on a non-multisite and when I asked for it to be excluded, I found this fatal error: it's missing a slash before the **`src`**

    PHP Fatal error:  require_once(): Failed opening required '/public_html/wp-content/plugins/multisite-enhancementssrc/settings.php' (include_path='.:/opt/alt/php74/usr/share/pear')

All the best!